### PR TITLE
Removes redudant class-name from H2 component

### DIFF
--- a/apps/www/registry/default/example/typography-h2.tsx
+++ b/apps/www/registry/default/example/typography-h2.tsx
@@ -1,6 +1,6 @@
 export default function TypographyH2() {
   return (
-    <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0">
+    <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
       The People of the Kingdom
     </h2>
   )

--- a/apps/www/registry/new-york/example/typography-h2.tsx
+++ b/apps/www/registry/new-york/example/typography-h2.tsx
@@ -1,6 +1,6 @@
 export default function TypographyH2() {
   return (
-    <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0">
+    <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
       The People of the Kingdom
     </h2>
   )


### PR DESCRIPTION
The class `transition-colors` need not be in the `h2` element. 
If the user wants they can add it externally, currently it is not used because there is no hover or focus effect declared.

This PR removes it from both `default` and `new-york` styles